### PR TITLE
Use HTTPS instead of HTTP

### DIFF
--- a/templates/user_test_beacon.js
+++ b/templates/user_test_beacon.js
@@ -97,7 +97,7 @@
     iframeDoc.close();
 
     var form = iframeDoc.createElement('form');
-    form.action = 'http://{{ server }}/beacon/{{ test_key }}';
+    form.action = 'https://{{ server }}/beacon/{{ test_key }}';
     form.method = 'post';
     var inputs = {
       'test_key': test_key,


### PR DESCRIPTION
This avoids mixed content errors when beaconing data from HTTPS pages.

This is currently a problem on jsPerf.

1. https://jsperf.com/slugs
1. Open DevTools console
1. Run test — at the end, it attempts to POST to Browserscope

Ref. https://github.com/jsperf/jsperf.com/issues/235