### PR TITLE
Use https for form action fixes #6 

### DIFF
--- a/templates/user_test_beacon.js
+++ b/templates/user_test_beacon.js
@@ -97,7 +97,7 @@
     iframeDoc.close();
 
     var form = iframeDoc.createElement('form');
-    form.action = 'http://{{ server }}/beacon/{{ test_key }}';
+    form.action = 'https://{{ server }}/beacon/{{ test_key }}';
     form.method = 'post';
     var inputs = {
       'test_key': test_key,


### PR DESCRIPTION
If the user is visiting a site using an SSL cert then you should post your data to browserscope.org using SSL. If you don't, you'll get a mixed content warning.

Fixes #6 